### PR TITLE
Add missing table.

### DIFF
--- a/db/migrate/20120710111111_create_cohabitants_notifications.rb
+++ b/db/migrate/20120710111111_create_cohabitants_notifications.rb
@@ -1,0 +1,8 @@
+class CreateCohabitantsNotifications < ActiveRecord::Migration
+  def change
+    create_table :cohabitants_notifications, id: false do |t|
+      t.integer :cohabitant_id
+      t.integer :notification_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,12 +24,12 @@ ActiveRecord::Schema.define(:version => 20120801125947) do
   end
 
   create_table "cohabitants_notifications", :id => false, :force => true do |t|
-    t.string "cohabitant_id",   :null => false
-    t.string "notification_id", :null => false
+    t.integer "cohabitant_id"
+    t.integer "notification_id"
   end
 
-  add_index "cohabitants_notifications", ["cohabitant_id"], :name => "index_cohabitants_notifications_on_cohabitant_id"
-  add_index "cohabitants_notifications", ["notification_id"], :name => "index_cohabitants_notifications_on_notification_id"
+  add_index "cohabitants_notifications", ["cohabitant_id", "notification_id"], :name => "c_n_index"
+  add_index "cohabitants_notifications", ["notification_id", "cohabitant_id"], :name => "n_c_index"
 
   create_table "notifications", :force => true do |t|
     t.integer  "user_id"


### PR DESCRIPTION
- The id option allows you to skip setting a primary key for a join table.
